### PR TITLE
Update fr.json

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -218,17 +218,17 @@
       "DOT": "Dégâts sur la durée",
       "Drain": "Drainé",
       "Enmity": "Provoqué",
-      "Heavy": "Lourd",
-      "Invoking": "Conjurer",
+      "Heavy": "Pesanteur",
+      "Invoking": "Incanter",
       "KnockedOut": "Inconscient",
       "Paralysis": "Paralysie",
       "Petrified": "Pétrifié",
       "Prone": "À terre",
       "Ready": "Prêt",
-      "Revivify": "Revirogant",
+      "Revivify": "Revigoré",
       "Silence": "Silence",
       "Sleep": "Sommeil",
-      "Stun": "Étourdissement",
+      "Stun": "Étourdis",
       "Weakness": "Faiblesse"
     },
     "Tags": {
@@ -395,3 +395,4 @@
     "False": "Faux"
   }
 }
+


### PR DESCRIPTION
Salut, j'ai fais quelques vérifications ingame pour les altérations d'état :
- Pour Heavy, il s'agit de Pesanteur
- Revigorant était mal orthographié et pas un adjectif
- Conjurer était trop confus et pas assez proche de l'état dans lequel un mage incante un sort, incanter semble plus à propos
- Pour Stun, on reste sur la même logique donc au lieu d'"étourdissement", on est "étourdis"